### PR TITLE
Fix PDF/image text extraction bug

### DIFF
--- a/bedrock-chat.py
+++ b/bedrock-chat.py
@@ -429,9 +429,8 @@ def exract_pdf_text_aws(file):
         else:
             img_bytes = io.BytesIO()
             s3.Bucket(bucket_name).download_fileobj(key, img_bytes)
-            img_bytes.seek(0)         
-            image_stream = io.BytesIO(img_bytes)
-            image = Image.open(image_stream)
+            img_bytes.seek(0)
+            image = Image.open(img_bytes)
             text = pytesseract.image_to_string(image)
         return text    
 

--- a/function_calling_utils.py
+++ b/function_calling_utils.py
@@ -560,11 +560,10 @@ def exract_pdf_text_aws(file):
         else:
             img_bytes = io.BytesIO()
             s3.Bucket(bucket_name).download_fileobj(key, img_bytes)
-            img_bytes.seek(0)         
-            image_stream = io.BytesIO(image_bytes)
-            image = Image.open(image_stream)
+            img_bytes.seek(0)
+            image = Image.open(img_bytes)
             text = pytesseract.image_to_string(image)
-        return text    
+        return text
 
 def detect_encoding(s3_uri):
     """detect csv encoding"""


### PR DESCRIPTION
## Summary
- correct BytesIO handling when reading images
- ensure Tesseract processes BytesIO correctly

## Testing
- `python -m py_compile bedrock-chat.py function_calling_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684be2e1d9408332b31343034eb1abff

## Summary by Sourcery

Bug Fixes:
- Remove redundant BytesIO wrapping and open images directly from the downloaded buffer in exract_pdf_text_aws in both modules